### PR TITLE
Remove extraneous comment from Charge action roll

### DIFF
--- a/src/content/resources/fari-rpgs/charge/index.mdx
+++ b/src/content/resources/fari-rpgs/charge/index.mdx
@@ -579,8 +579,6 @@ There could be scenarios where adding tension isn't an option. In that case, the
 
 When you **assist** a PC, you consume **1 momentum**, to give an extra **1d6** to their roll. When doing this, you also expose yourself to possible danger.
 
-You can also even the odds by using **either** of the following methods.
-
 > \#### Use an Asset
 >
 > Assets are an optional rule available in [Extras&nbsp;»&nbsp;Asset Extra](asset-extra) which gives an additional way to even the odds.


### PR DESCRIPTION
A line in Assist seems to refer to Push Yourself and Add Tension, but those sections appear earlier in the text.